### PR TITLE
Transloom: Approved translation — de/empty_list

### DIFF
--- a/values-de/strings.xml
+++ b/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="empty_list"/>
+</resources>


### PR DESCRIPTION
Manual approval of translation for key `empty_list` in **de**.

> Approved via the Transloom review portal.