### PR TITLE
Transloom: Approved translation — de/default_coordinates_txt

### DIFF
--- a/values-de/strings.xml
+++ b/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="default_coordinates_txt"/>
+</resources>


### PR DESCRIPTION
Manual approval of translation for key `default_coordinates_txt` in **de**.

> Approved via the Transloom review portal.