### PR TITLE
Transloom: Approved translation — de/no_internet_txt

### DIFF
--- a/values-de/strings.xml
+++ b/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="no_internet_txt"/>
+</resources>


### PR DESCRIPTION
Manual approval of translation for key `no_internet_txt` in **de**.

> Approved via the Transloom review portal.