### PR TITLE
Transloom: Approved translation — de/server_error_txt

### DIFF
--- a/values-de/strings.xml
+++ b/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="server_error_txt"/>
+</resources>


### PR DESCRIPTION
Manual approval of translation for key `server_error_txt` in **de**.

> Approved via the Transloom review portal.