### PR TITLE
Transloom: Approved translation — it/general_error_txt

### DIFF
--- a/values-it/strings.xml
+++ b/values-it/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="general_error_txt"/>
+</resources>


### PR DESCRIPTION
Manual approval of translation for key `general_error_txt` in **it**.

> Approved via the Transloom review portal.