### PR TITLE
Transloom: Approved translation — it/no_internet_txt

### DIFF
--- a/values-it/strings.xml
+++ b/values-it/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="no_internet_txt"/>
+</resources>


### PR DESCRIPTION
Manual approval of translation for key `no_internet_txt` in **it**.

> Approved via the Transloom review portal.