### PR TITLE
Transloom: Approved translation — de/got_it

### DIFF
--- a/values-de/strings.xml
+++ b/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="got_it"/>
+</resources>


### PR DESCRIPTION
Manual approval of translation for key `got_it` in **de**.

> Approved via the Transloom review portal.