### PR TITLE
Transloom: Approved translation — de/hourly_forecast_heading_txt

### DIFF
--- a/values-de/strings.xml
+++ b/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="hourly_forecast_heading_txt"/>
+</resources>


### PR DESCRIPTION
Manual approval of translation for key `hourly_forecast_heading_txt` in **de**.

> Approved via the Transloom review portal.