### PR TITLE
Transloom: Approved translation — it/air_quality

### DIFF
--- a/values-it/strings.xml
+++ b/values-it/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="air_quality"/>
+</resources>


### PR DESCRIPTION
Manual approval of translation for key `air_quality` in **it**.

> Approved via the Transloom review portal.