### PR TITLE
Syncling: 1 reviewed translation · 1 language

### DIFF
--- a/values-ko/strings.xml
+++ b/values-ko/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="network_unavailable_txt">인터넷 연결을 다시 확인해 주세요!</string>
+</resources>


### PR DESCRIPTION
## Syncling: Approved Translations

| Language | Strings | Keys |
|---|---|---|
| KO | 1 | `network_unavailable_txt` |

> Manually reviewed and approved via the Syncling review portal.

*Generated by [Syncling](https://syncling.dev)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release adds Korean language localization for network connectivity error messages. Korean-speaking users will now receive network-related error notifications displayed in their native language, significantly improving accessibility and user experience when connectivity issues occur.

* **New Features**
  * Korean language support for network unavailability messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->