### PR TITLE
Syncling: 1 reviewed translation · 1 language

### DIFF
--- a/values-th/strings.xml
+++ b/values-th/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="network_unavailable_txt">รบกวนตรวจสอบการเชื่อมต่ออินเทอร์เน็ตอีกครั้ง!</string>
+</resources>


### PR DESCRIPTION
## Syncling: Approved Translations

| Language | Strings | Keys |
|---|---|---|
| TH | 1 | `network_unavailable_txt` |

> Manually reviewed and approved via the Syncling review portal.

*Generated by [Syncling](https://syncling.dev)*